### PR TITLE
FIX: Enable feedback viewer for instructor impersonation

### DIFF
--- a/src/app/api/student/feedback/route.ts
+++ b/src/app/api/student/feedback/route.ts
@@ -22,8 +22,12 @@ export async function GET(request: NextRequest) {
       );
     }
     
-    // Students can only access their own feedback
-    if (session.user.role !== 'STUDENT') {
+    // Students can access their own feedback
+    // Instructors in impersonation mode can also access
+    const isStudent = session.user.role === 'STUDENT';
+    const isInstructorImpersonating = session.user.role === 'INSTRUCTOR' && session.user.isImpersonating;
+
+    if (!isStudent && !isInstructorImpersonating) {
       return NextResponse.json(
         { error: 'This endpoint is for students only' },
         { status: 403 }


### PR DESCRIPTION
## 🐛 Problem

Instructors in "modo vista" (impersonation mode) were unable to view student feedbacks. When clicking "📝 Devolución" button, the API returned 403 Forbidden because the endpoint only accepted `STUDENT` role.

### Evidence:
- **Student:** Franco Nuñez (EST-2025-095)
- **Feedbacks in DB:** 13 records confirmed ✅
- **Error:** `/api/student/feedback` rejected INSTRUCTOR role ❌

## 🔧 Solution

Modified `/src/app/api/student/feedback/route.ts` to allow instructors in impersonation mode, following the same pattern used in `/api/student/evaluations` endpoint.

### Changes:
```typescript
// Before
if (session.user.role !== 'STUDENT') {
  return NextResponse.json({ error: 'This endpoint is for students only' }, { status: 403 });
}

// After
const isStudent = session.user.role === 'STUDENT';
const isInstructorImpersonating = session.user.role === 'INSTRUCTOR' && session.user.isImpersonating;

if (!isStudent && !isInstructorImpersonating) {
  return NextResponse.json({ error: 'This endpoint is for students only' }, { status: 403 });
}
```

## ✅ Testing

- [x] TypeScript compilation passes
- [x] ESLint passes (only pre-existing warnings)
- [x] Build completes successfully
- [x] No breaking changes to existing functionality

## 📊 Impact

- **Users affected:** All instructors using "modo vista" (169+ potential users)
- **Risk:** LOW (minimal change, proven pattern from evaluations endpoint)
- **Benefit:** Instructors can now fully monitor student feedbacks

## 🔗 Related

Fixes the issue where feedbacks were not accessible when viewing student profiles as instructor.